### PR TITLE
Activate win-64 R3.5 build again

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,8 +12,8 @@ environment:
     - CONFIG: win_r_base3.4.1
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    #- CONFIG: win_r_base3.5.1
-    #  CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+    - CONFIG: win_r_base3.5.1
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,2 @@
-"%R%" -e "devtools::build()"
-"%R%" -e "devtools::install()"
+"%R%" CMD INSTALL --build .
 IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-$R -e 'devtools::install()'
+$R CMD INSTALL --build .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,6 +4,8 @@
 {% set sha256 = "9b58c4e821081940ddf73c0ab68d341b68a277673581c0ed319753cbaadd01ef" %}  # [win]
 {% set sha256 = "0cba6fbf4483440c39b18c3c9e164c34e5954543c8416020a36fbb80101fd3bd" %}  # [osx]
 
+{% set posix = 'm2-' if win else '' %}
+
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -19,10 +21,15 @@ build:
 
 requirements:
   build:
+    - {{posix}}zip               # [win]
+
+  host:
     - r-base
-    - r-devtools
+    - r-jsonlite
+
   run:
     - r-base
+    - r-jsonlite
 
 test:
  commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This was previously deactivated because of failing build due to devtools errors.